### PR TITLE
FIX: Deployment issues with pm2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 My person website & playground.
 
-
 ```bash
 # use this to login to the remote server
 ssh root@192.241.216.26
@@ -13,6 +12,18 @@ bun run check
 bun run build:tailwind
 bun run build
 bun run preview
+
+# save the process with pm2
+pm2 start --name "asleepace.com" --watch --interpreter $(which bun) dist/server/entry.mjs
+
+# NGINX Configuration
+sudo nano /etc/nginx/sites-available/asleepace.com
+sudo ln -s /etc/nginx/sites-available/asleepace.com /etc/nginx/sites-enabled/asleepace.com
+
+# Test the NGINX configuration
+sudo nginx -t
+sudo systemctl restart nginx
+sudo systemctl reload nginx
 ```
 
 # Server Commands
@@ -26,15 +37,16 @@ ssh root@192.241.216.26
 Build the website from scratch
 
 ```bash
-yarn install
-yarn build
+bun i
+bun run build:tailwind
+bun run build
 ```
 
-Start the process with **pm2** run the following commands
+Start the process with **pm2** run the following commands, since the application now uses ASDF we need to specify the path to the bun executable.
 
 ```bash
-pm2 stop --all
-pm2 start ./dist/server/entry.mjs --name asleepace.com
+pm2 stop asleepace.com
+pm2 start --name "asleepace.com" --watch --interpreter $(which bun) dist/server/entry.mjs
 ```
 
 Use the following command to restart the postgres server

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "check": "bun --bun astro check",
     "dev": "bunx --bun astro dev",
-    "start": "bunx --bun astro build --port 4000 && bunx --bun astro preview --port 4000",
+    "start": "bunx --bun astro build --port 4321 && bunx --bun astro preview --port 4321",
     "build": "bunx --bun astro build",
     "build:debug": "DEBUG=astro:*,vite:* bunx --bun astro build --verbose",
     "preview": "bunx --bun astro preview",
@@ -15,7 +15,8 @@
     "deploy": "./scripts/deploy.sh",
     "astro": "bunx --bun astro",
     "util:upgrade": "bun upgrade",
-    "util:check": "bunx --bun astro check"
+    "util:check": "bunx --bun astro check",
+    "run:server": "bun ./dist/server/entry.mjs"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",


### PR DESCRIPTION
# Overview

This pull request fixes a deployment issue with pm2 and ASDF since it points to the wrong global version. Here is the new command:

```bash
pm2 start --name "asleepace.com" --watch --interpreter $(which bun) dist/server/entry.mjs
```

The `dist/server/entry.mjs` file is generated during the build process.

- https://bun.sh/guides/ecosystem/pm2
- https://docs.astro.build/en/guides/integrations-guide/node/